### PR TITLE
Optional marker class as argument to datasetclass decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Editor settings
 .vscode
 
+# Editor workspace
+*.code-workspace
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/poetry.lock
+++ b/poetry.lock
@@ -332,6 +332,22 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy"
+version = "0.812"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -804,7 +820,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "255a9f487b6be31f34b00b3b14a529c7375f25374fddfd65ec462500603bf315"
+content-hash = "f703d3c5738aa749c590b19392497d49bd5bfcefc06dd9eda00d302936c3e78c"
 
 [metadata.files]
 alabaster = [
@@ -987,6 +1003,30 @@ markupsafe = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy = [
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ ipykernel = "^5.5"
 pydata-sphinx-theme = "^0.4"
 pytest = "^6.2"
 sphinx = "^3.5"
+mypy = "^0.812"
 
 [build-system]
 requires = ["poetry>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://astropenguin.github.io/xarray-dataclasses/"
 python = "^3.7"
 numpy = "^1.19"
 typing-extensions = "^3.7"
-xarray = "^0.15"
+xarray = ">= 0.15, ^0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b"

--- a/tests/test_dataset_extend_xarray.py
+++ b/tests/test_dataset_extend_xarray.py
@@ -23,7 +23,7 @@ class ImageDataset:
     __slots__ = tuple()
 
 
-@datasetclass(extend_xarray=ImageDataset)
+@datasetclass(xarray_base=ImageDataset)
 class Image:
     data: Data[Tuple[X, Y], float]
 
@@ -32,7 +32,7 @@ class ImageMaskedDataset:
     __slots__ = tuple()
 
 
-@datasetclass(extend_xarray=ImageMaskedDataset)
+@datasetclass(xarray_base=ImageMaskedDataset)
 class ImageMasked:
     data: Data[Tuple[X, Y], float]
     mask: Data[Tuple[X, Y], bool]

--- a/tests/test_dataset_extend_xarray.py
+++ b/tests/test_dataset_extend_xarray.py
@@ -28,7 +28,7 @@ class Image:
     data: Data[Tuple[X, Y], float]
 
 
-class ImageMaskedDataset:
+class ImageMaskedDataset(xr.Dataset):
     __slots__ = tuple()
 
 
@@ -50,13 +50,13 @@ def check_image_masked(x: xr.Dataset) -> str:
 
 
 @check_image_masked.register
-def _(x: ImageDataset):
+def check_image_masked_i(x: ImageDataset) -> str:
     return "unmasked"
 
 
 @check_image_masked.register
-def _(x: ImageMaskedDataset):
-    return "masked"
+def check_image_masked_im(x: ImageMaskedDataset) -> str:
+    return f"masked; len = {len(x.data)}"
 
 
 def test_dataset_singledispatch():
@@ -65,5 +65,6 @@ def test_dataset_singledispatch():
         check_image_masked(generic)
     assert check_image_masked(Image.new([[1]]) == "unmasked")
     assert (
-        check_image_masked(ImageMasked.new([[1]], [[True]])) == "masked"
+        check_image_masked(ImageMasked.new([[1]], [[True]]))
+        == "masked; len = 1"
     )

--- a/tests/test_dataset_extend_xarray.py
+++ b/tests/test_dataset_extend_xarray.py
@@ -1,0 +1,69 @@
+"""
+Test `extend_xarray` option.
+
+With this option, dataset dataclass `new` should return
+an instance which is derived from dataclass as well as xarray.
+"""
+from functools import singledispatch
+from typing import Literal, Tuple
+import pytest
+
+import xarray as xr
+from xarray_dataclasses import datasetclass, Data
+
+# constants
+DIMS = "x", "y"
+
+# type hints
+X = Literal[DIMS[0]]
+Y = Literal[DIMS[1]]
+
+
+class ImageDataset:
+    __slots__ = tuple()
+
+
+@datasetclass(extend_xarray=ImageDataset)
+class Image:
+    data: Data[Tuple[X, Y], float]
+
+
+class ImageMaskedDataset:
+    __slots__ = tuple()
+
+
+@datasetclass(extend_xarray=ImageMaskedDataset)
+class ImageMasked:
+    data: Data[Tuple[X, Y], float]
+    mask: Data[Tuple[X, Y], bool]
+
+
+def test_dataset_extend_xarray():
+    image = Image.new([[1, 2], [3, 4]])
+    assert isinstance(image, xr.Dataset)
+    assert isinstance(image, ImageDataset)
+
+
+@singledispatch
+def check_image_masked(x: xr.Dataset) -> str:
+    raise TypeError("Not image?")
+
+
+@check_image_masked.register
+def _(x: ImageDataset):
+    return "unmasked"
+
+
+@check_image_masked.register
+def _(x: ImageMaskedDataset):
+    return "masked"
+
+
+def test_dataset_singledispatch():
+    generic = xr.Dataset(data_vars=dict())
+    with pytest.raises(TypeError):
+        check_image_masked(generic)
+    assert check_image_masked(Image.new([[1]]) == "unmasked")
+    assert (
+        check_image_masked(ImageMasked.new([[1]], [[True]])) == "masked"
+    )

--- a/xarray_dataclasses/utils.py
+++ b/xarray_dataclasses/utils.py
@@ -106,7 +106,12 @@ def make_marked_subclass(
     The intention is that `cls` provides functionality; `mark_class`
     is a mixin that just provides name, and the ability to test
     distinct type of `cls` via `instanceof` or `issubclass`.
+
+    Alternately, if `cls` is a subclass of `mark_class`, we
+    simply pass back `mark_class`
     """
+    if issubclass(mark_class, cls):
+        return mark_class
     bases = (cls, mark_class)
     return cast(
         Type[OT],

--- a/xarray_dataclasses/utils.py
+++ b/xarray_dataclasses/utils.py
@@ -5,7 +5,17 @@ __all__ = ["copy_class", "copy_func", "copy_wraps", "extend_class"]
 from copy import copy, deepcopy
 from functools import wraps, WRAPPER_ASSIGNMENTS, WRAPPER_UPDATES
 from types import FunctionType
-from typing import Callable, Sequence, TypeVar
+from typing import (
+    Callable,
+    Dict,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Any,
+    TypeVar,
+    cast,
+)
 
 
 # type hints (internal)
@@ -80,3 +90,25 @@ def extend_class(cls: type, mixin: type) -> type:
         bases = (*cls.__bases__, mixin)
 
     return type(cls.__name__, bases, cls.__dict__.copy())
+
+
+OT = TypeVar("OT")
+
+
+def make_marked_subclass(
+    cls: Type[OT],
+    mark_class: Type[Any],
+    attrs: Dict[str, Any] = {},
+) -> Type[OT]:
+    """
+    Create class deriving from `cls`, extra base `mark_class`.
+
+    The intention is that `cls` provides functionality; `mark_class`
+    is a mixin that just provides name, and the ability to test
+    distinct type of `cls` via `instanceof` or `issubclass`.
+    """
+    bases = (cls, mark_class)
+    return cast(
+        Type[OT],
+        type(mark_class.__name__, bases, attrs),  # type: ignore
+    )


### PR DESCRIPTION
The goal is that the returned xarray (optionally) can be distinguished with `isinstance` from a generic xarray.

My use case is to use with `functools.singledispatch` -- I have two datasets representing different kinds of patterns, sharing 9 data arrays in common but with two variants. I would like to define variant processing in some cases using `@signledispatch`. I have added a test of this functionality.

Some of the type-related code is awkward. I was originally going to have a generic class as the marker "`DatasetOf[Foo]`" where `Foo` is the datasetclass, but seems that single dispatch won't branch on such.

If you like the idea but want a different implementation, I'm happy to amend.