### PR TITLE
Extend Dataset: annotate via baseclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+xarray-dataclasses.code-workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://astropenguin.github.io/xarray-dataclasses/"
 python = "^3.7"
 numpy = "^1.19"
 typing-extensions = "^3.7"
-xarray = "^0.15"
+xarray = ">= 0.15, ^0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -11,7 +11,7 @@ from typing_extensions import Literal
 
 # submodules
 from xarray_dataclasses.dataarray import DataArrayMixin
-from xarray_dataclasses.dataset import DatasetMixin
+from xarray_dataclasses.dataset import WithNew
 from xarray_dataclasses.typing import Attr, Coord, Data
 
 # constants
@@ -31,7 +31,7 @@ class Image(DataArrayMixin):
 
 
 @dataclass
-class RGBImage(DatasetMixin):
+class RGBImage(WithNew):
     red: Data[Tuple[X, Y], float]
     green: Data[Tuple[X, Y], float]
     blue: Data[Tuple[X, Y], float]

--- a/tests/test_dataset_extend_xarray.py
+++ b/tests/test_dataset_extend_xarray.py
@@ -1,0 +1,76 @@
+"""
+Test `extend_xarray` option.
+
+With this option, dataset dataclass `new` should return
+an instance which is derived from dataclass as well as xarray.
+"""
+from typing import Literal, Tuple
+import pytest
+
+import xarray as xr
+from xarray_dataclasses import datasetclass, Data
+from xarray_dataclasses.typing import DataClassX, WithClass
+from xarray_dataclasses.dataset import WithNewX
+
+# constants
+DIMS = ("x", "y")
+
+# type hints
+X = Literal["x"]
+Y = Literal["y"]
+
+
+class ImageDataset(xr.Dataset):
+    __slots__ = ()
+    data: xr.DataArray
+
+
+@datasetclass
+class ImageU:
+    data: Data[Tuple[X, Y], float]
+
+
+@datasetclass
+class ImageC(WithClass[ImageDataset]):
+    data: Data[Tuple[X, Y], float]
+
+
+@datasetclass
+class ImageX(DataClassX[ImageDataset]):
+    data: Data[Tuple[X, Y], float]
+
+
+@datasetclass
+class ImageW(WithNewX[ImageDataset]):
+    data: Data[Tuple[X, Y], float]
+
+
+def test_dataset_extend_base():
+    image = ImageU.new([[1, 2], [3, 4]])
+    assert ImageU.new.__annotations__["return"] == xr.Dataset
+    assert not isinstance(image, ImageDataset)
+
+
+def test_dataset_extend_wc():
+    image = ImageU.new([[1, 2], [3, 4]])
+    assert ImageU.new.__annotations__["return"] == xr.Dataset
+    assert not isinstance(image, ImageDataset)
+    foo(image)  # static typing doesn't work?
+
+
+def test_dataset_extend_dataclass_base():
+    image = ImageX.new([[1, 2], [3, 4]])
+    assert ImageX.new.__annotations__["return"] == ImageDataset
+    assert isinstance(image, ImageDataset)
+    foo(image)  # static typing works
+
+
+def test_dataset_extend_with_new():
+    image = ImageW.new([[1, 2], [3, 4]])
+    assert ImageW.new.__annotations__["return"] == ImageDataset
+    assert isinstance(image, ImageDataset)
+    foo(image)
+
+
+def foo(imageDataset: ImageDataset):
+    pass

--- a/xarray_dataclasses/dataset.py
+++ b/xarray_dataclasses/dataset.py
@@ -8,7 +8,17 @@ __all__ = ["asdataset", "datasetclass"]
 from dataclasses import dataclass
 from functools import wraps
 from types import FunctionType
-from typing import Any, Callable, Generic, cast, Optional, Type, Union
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Literal,
+    cast,
+    Optional,
+    Type,
+    Union,
+    overload,
+)
 
 
 # third-party packages
@@ -17,7 +27,7 @@ import xarray as xr
 
 # submodules
 from .common import get_attrs, get_coords, get_data_vars
-from .typing import DS, DataClass
+from .typing import DS, DataClass, DataClassX, WithClass
 from .utils import copy_class, extend_class
 
 
@@ -25,10 +35,27 @@ from .utils import copy_class, extend_class
 TEMP_CLASS_PREFIX: str = "__Copied"
 
 
+@overload
+def asdataset(inst: DataClassX[DS]) -> DS:
+    ...
+
+
+@overload
+def asdataset(inst: DataClass) -> xr.Dataset:
+    ...
+
+
 # runtime functions (public)
-def asdataset(inst: DataClass[DS]) -> DS:
+def asdataset(
+    inst: Union[DataClass, DataClassX[DS]]
+) -> Union[xr.Dataset, DS]:
     """Convert a Dataset-class instance to Dataset one."""
-    dataset = xr.Dataset(get_data_vars(inst))
+    if hasattr(inst.__class__, "__dataset_class__"):
+        dataset: Union[xr.Dataset, DS] = cast(
+            WithClass[DS], inst
+        ).__dataset_class__(get_data_vars(inst))
+    else:
+        dataset = xr.Dataset(get_data_vars(inst))
     coords = get_coords(inst, dataset)
 
     dataset.coords.update(coords)
@@ -37,39 +64,7 @@ def asdataset(inst: DataClass[DS]) -> DS:
     return dataset
 
 
-def datasetclass(
-    cls: Optional[type] = None,
-    *,
-    init: bool = True,
-    repr: bool = True,
-    eq: bool = True,
-    order: bool = False,
-    unsafe_hash: bool = False,
-    frozen: bool = False,
-    shorthands: bool = True,
-) -> Union[Type[DataClass], Callable[[type], Type[DataClass]]]:
-    """Class decorator to create a Dataset class."""
-
-    def to_dataclass(cls: type) -> Type[DataClass[DS]]:
-        if shorthands and not issubclass(cls, WithNew):
-            cls = extend_class(cls, WithNew)
-
-        return dataclass(
-            init=init,
-            repr=repr,
-            eq=eq,
-            order=order,
-            unsafe_hash=unsafe_hash,
-            frozen=frozen,
-        )(cls)
-
-    if cls is None:
-        return to_dataclass
-    else:
-        return to_dataclass(cls)
-
-
-class WithNew(Generic[DS], DataClass[DS]):
+class WithNewX(Generic[DS], WithClass[DS]):
     """Mix-in class that provides shorthand methods."""
 
     @classmethod
@@ -83,27 +78,189 @@ class WithNew(Generic[DS], DataClass[DS]):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Update new() based on the dataclass definition."""
-        super().__init_subclass__(**kwargs)
-
+        super().__init_subclass__()  # type: ignore
         # temporary class only for getting dataclass __init__
         try:
-            Temp = dataclass(copy_class(cls, TEMP_CLASS_PREFIX))
+            Temp: type = dataclass(copy_class(cls, TEMP_CLASS_PREFIX))
         except ValueError:
             return
 
         init: FunctionType = Temp.__init__  # type: ignore
-        init.__annotations__["return"] = cls.__dataset_class__
+        dataset_class = cast(Type[DS], _find_dataset_class_for(cls))
+        init.__annotations__["return"] = dataset_class
 
         # create a concrete new method and bind
-        @classmethod
+        @classmethod  # type: ignore
         @wraps(init)
         def new(
-            cls,  # type: ignore
+            cls: "Type[WithNewX[DS]]",  # type: ignore
             *args: Any,
             **kwargs: Any,
         ) -> DS:
             """Create a Dataset instance."""
-            cls = cast(Type[DataClass], cls)
             return asdataset(cls(*args, **kwargs))
 
         cls.new = new  # type: ignore
+
+
+WithNew = WithNewX[xr.Dataset]
+
+
+# possible types of class decorated
+DecInU = Type[object]
+DecInB = Type[DataClass]
+DecInX = Type[DataClassX[DS]]
+DecInW = Type[WithNewX[DS]]
+DecIn = Union[DecInU, DecInB, DecInX[DS], DecInW[DS]]
+
+# possible result types of decorator
+DecOutU = DataClass
+DecOutB = DataClassX[xr.Dataset]
+DecOutX = DataClassX[DS]
+DecOut = Union[DecOutU, DecOutB, DecOutX[DS], DecInW[DS]]
+
+# Possible "bare" decorator calls:
+
+# untyped in -> implicit xr.Dataset
+DCDecoratorU = Callable[[DecInU], DecOutU]
+
+# base implicit xr.Dataset
+DCDecoratorB = Callable[[DecInB], DecOutB]
+
+# explicit derived xarray
+DCDecoratorX = Callable[[DecInX[DS]], DecOutX[DS]]
+
+# explicit "WithNew"
+DCDecoratorW = Callable[[DecInW[DS]], DecInW[DS]]
+
+# untyped in -> WithNew specialized for xr.Dataset
+DCDecoratorWU = Callable[[DecInU], DecInW[xr.Dataset]]
+
+# all decorators
+DCDecorator = Union[
+    DCDecoratorU,
+    DCDecoratorB,
+    DCDecoratorX[DS],
+    DCDecoratorW[DS],
+    DCDecoratorWU,
+]
+
+# all without shorthand
+DCDecoratorNS = Union[DCDecoratorU, DCDecoratorB, DCDecoratorX[DS]]
+
+# all with shorthand
+DCDecoratorS = Union[DCDecoratorW[DS], DCDecoratorWU]
+
+
+@overload
+def datasetclass(cls: DecInX[DS]) -> WithNewX[DS]:
+    ...
+
+
+@overload
+def datasetclass(cls: DecInU) -> "WithNewX[xr.Dataset]":
+    ...
+
+
+# @overload
+# def datasetclass(
+#     *,
+#     shorthands: Literal[False],
+#     init: bool = True,
+#     repr: bool = True,
+#     eq: bool = True,
+#     order: bool = False,
+#     unsafe_hash: bool = False,
+#     frozen: bool = False,
+# ) -> DCDecoratorNS[DS]:
+#     ...
+
+
+@overload
+def datasetclass(
+    *,
+    shorthands: Literal[False],
+    init: bool = True,
+    repr: bool = True,
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+) -> Callable[[Union[DecInU, DecInB]], Union[DecOutU, DecOutB]]:
+    ...
+
+
+@overload
+def datasetclass(
+    *,
+    shorthands: Literal[True],
+    init: bool = True,
+    repr: bool = True,
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+) -> DCDecoratorS[DS]:
+    ...
+
+
+def datasetclass(
+    cls: Optional[DecIn[DS]] = None,
+    *,
+    init: bool = True,
+    repr: bool = True,
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+    shorthands: bool = True,
+) -> Union[DecOut[DS], DCDecorator[DS]]:
+    """Class decorator to create a Dataset class."""
+
+    def to_dataclass(cls: DecIn[DS]) -> DecOut[DS]:
+        if issubclass(cls, WithClass):
+            dataset_class = cast(Type[DS], _find_dataset_class_for(cls))
+            cls.__dataset_class__ = dataset_class  # type: ignore
+        if shorthands and not issubclass(cls, WithNewX):
+            cls = extend_class(cls, WithNewX)
+
+        dc = dataclass(
+            init=init,
+            repr=repr,
+            eq=eq,
+            order=order,
+            unsafe_hash=unsafe_hash,
+            frozen=frozen,
+        )(cls)
+        return cast(DecOut[DS], dc)
+
+    if cls is None:
+        return cast(DCDecorator[DS], to_dataclass)
+    else:
+        return to_dataclass(cls)
+
+
+def _find_dataset_class_for(cls: Union[WithClass[DS], Any]) -> Type[DS]:
+    """
+    Get dataset class from base annotation if available.
+
+    If `cls` is declared as `Spec(WithClass[DerivedDataset])`
+    for some `xr.Dataset` derivative `DerivedDataset`, this annotation
+    is preserved in `cls` metadata, from which we extract it.
+
+    WARNING: will look for classes derived from `WithClass`
+    in bases, and takes first instantiation of a generic that
+    derives from `xr.Dataset`. The user could confound this mechanism
+    by (e.g.) adding generic parameters for other purposes.
+    """
+    if not hasattr(cls, "__orig_bases__"):
+        return cast(Type[DS], xr.Dataset)
+    for g_base in cast(Any, cls).__orig_bases__:
+        if not issubclass(g_base.__origin__, WithClass):
+            continue
+        for g_arg in g_base.__args__:
+            if isinstance(g_arg, type) and issubclass(
+                g_arg, xr.Dataset
+            ):
+                return cast(Type[DS], g_arg)
+    return cast(Type[DS], xr.Dataset)

--- a/xarray_dataclasses/dataset.py
+++ b/xarray_dataclasses/dataset.py
@@ -256,7 +256,9 @@ def _find_dataset_class_for(cls: Union[WithClass[DS], Any]) -> Type[DS]:
     if not hasattr(cls, "__orig_bases__"):
         return cast(Type[DS], xr.Dataset)
     for g_base in cast(Any, cls).__orig_bases__:
-        if not issubclass(g_base.__origin__, WithClass):
+        if not hasattr(g_base, "__origin__") or not issubclass(
+            g_base.__origin__, WithClass
+        ):
             continue
         for g_arg in g_base.__args__:
             if isinstance(g_arg, type) and issubclass(

--- a/xarray_dataclasses/typing.py
+++ b/xarray_dataclasses/typing.py
@@ -7,6 +7,7 @@ from enum import auto, Enum
 from typing import (
     Any,
     Callable,
+    Generic,
     cast,
     Dict,
     ForwardRef,
@@ -69,12 +70,19 @@ class DataArray(Protocol[D, T]):
     __array__: Callable[..., np.ndarray]
 
 
-class DataClass(Protocol[DS]):
+class DataClass(Protocol):
     """Type hint for dataclass instance."""
 
     __init__: Callable[..., None]
     __dataclass_fields__: FieldDict
+
+
+class WithClass(Generic[DS]):
     __dataset_class__: Type[DS]
+
+
+class DataClassX(DataClass, WithClass[DS]):
+    ...
 
 
 DataArrayLike = Union[DataArray[D, T], ndarray[T], Sequence[T], T]

--- a/xarray_dataclasses/typing.py
+++ b/xarray_dataclasses/typing.py
@@ -21,6 +21,7 @@ from typing import (
 
 # third-party packages
 import numpy as np
+import xarray as xr
 from typing_extensions import (
     Annotated,
     Final,
@@ -49,6 +50,7 @@ class Xarray(Enum):
 # type hints (internal)
 D = TypeVar("D", covariant=True)
 T = TypeVar("T", covariant=True)
+DS = TypeVar("DS", bound=xr.Dataset)
 
 DTypeLike = Union[np.dtype, type, str, None]
 FieldDict = Dict[str, Field]
@@ -67,11 +69,12 @@ class DataArray(Protocol[D, T]):
     __array__: Callable[..., np.ndarray]
 
 
-class DataClass(Protocol):
+class DataClass(Protocol[DS]):
     """Type hint for dataclass instance."""
 
     __init__: Callable[..., None]
     __dataclass_fields__: FieldDict
+    __dataset_class__: Type[DS]
 
 
 DataArrayLike = Union[DataArray[D, T], ndarray[T], Sequence[T], T]

--- a/xarray_dataclasses/typing.py
+++ b/xarray_dataclasses/typing.py
@@ -51,6 +51,8 @@ class Xarray(Enum):
 # type hints (internal)
 D = TypeVar("D", covariant=True)
 T = TypeVar("T", covariant=True)
+
+# create dataset type (internal)
 DS = TypeVar("DS", bound=xr.Dataset)
 
 DTypeLike = Union[np.dtype, type, str, None]

--- a/xarray_dataclasses/utils.py
+++ b/xarray_dataclasses/utils.py
@@ -5,7 +5,8 @@ __all__ = ["copy_class", "copy_func", "copy_wraps", "extend_class"]
 from copy import copy, deepcopy
 from functools import wraps, WRAPPER_ASSIGNMENTS, WRAPPER_UPDATES
 from types import FunctionType
-from typing import Callable, Sequence, TypeVar
+import types
+from typing import Callable, Sequence, Tuple, Type, TypeVar, cast
 
 
 # type hints (internal)
@@ -22,7 +23,7 @@ def copy_class(cls: type, prefix: str = "Copied") -> type:
     name = prefix + cls.__name__
 
     if cls.__bases__ == (object,):
-        bases = ()
+        bases: Tuple[type, ...] = ()
     else:
         bases = cls.__bases__
 

--- a/xarray_dataclasses/utils.py
+++ b/xarray_dataclasses/utils.py
@@ -74,6 +74,8 @@ def copy_wraps(
 
 def extend_class(cls: type, mixin: type) -> type:
     """Extend a class with a mix-in class."""
+    if issubclass(cls, mixin):
+        return cls
     if cls.__bases__ == (object,):
         bases = (mixin,)
     else:


### PR DESCRIPTION
Initial implementation of https://github.com/astropenguin/xarray-dataclasses/pull/41#issuecomment-812760625

Work in progress -- proving concept.

```python

class ImageDataset(xr.Dataset):
    __slots__ = ()
    data: xr.DataArray

@datasetclass
class ImageW(WithNewX[ImageDataset]):
    data: Data[Tuple[X, Y], float]

def test_dataset_extend_with_new():
    image = ImageW.new([[1, 2], [3, 4]])
    assert ImageW.new.__annotations__["return"] == ImageDataset
    assert isinstance(image, ImageDataset)
    foo(image)  # static typing works


def foo(imageDataset: ImageDataset):
    pass
```
I wasn't sure how you would like the base classes  -- eg have a "clean" version of DataClass w/o __dataset_class__ ... etc... In the end this sort of does it "all ways" -- but could be simplified depending on what you want. 

The overload annotations still have lots of extra junk from hacking. They were hard to get working. Internally there are still lots of typecasts, but from users perspective, the typing seems to work, I think.

